### PR TITLE
Fix token auth

### DIFF
--- a/FatZebra.class.php
+++ b/FatZebra.class.php
@@ -226,12 +226,12 @@ class Gateway {
      * Performs an authorization against the FatZebra gateway with a tokenized credit card
      * @param float $amount the purchase amount
      * @param string $reference the purchase reference
-     * @param string $card_token the card token or alias for the authorization
+     * @param string $token the card token or alias for the authorization
      * @param string $currency the currency code for the transaction. Defaults to AUD
      * @param array<string,string> $extra an assoc. array of extra params to merge into the request (e.g. metadata, fraud etc)
      * @return \StdObject
      */
-    public function token_authorization($amount, $reference, $card_token, $currency = "AUD", $extra = null) {
+    public function token_authorization($amount, $reference, $token, $currency = "AUD", $extra = null) {
         if(is_null($amount)) throw new \InvalidArgumentException("Amount is a required field.");
         if(is_null($reference)) throw new \InvalidArgumentException("Reference is a required field.");
         if(strlen($reference) === 0) throw new \InvalidArgumentException("Reference is a required field.");
@@ -243,10 +243,10 @@ class Gateway {
 
         $payload = array(
             'customer_ip' => $customer_ip,
-            'card_token' => $card_token,
-            'reference' => $this->reference,
+            'card_token' => $token,
+            'reference' => $reference,
             'amount' => $int_amount,
-            'currency' => $this->currency,
+            'currency' => $currency,
             'capture' => false
         );
 

--- a/FatZebra.class.php
+++ b/FatZebra.class.php
@@ -69,6 +69,11 @@ class Gateway {
     private $ca = "";
 
     /**
+     * Customer real IP to send.
+     */
+    private $customer_ip;
+
+    /**
      * Creates a new instance of the Fat Zebra gateway object
      * @param string $username the username for the gateway
      * @param string $token the token for the gateway
@@ -479,18 +484,29 @@ class Gateway {
     }
 
     /**
-     * Fetches the customers 'real' IP address (i.e. pulls out the address from X-Forwarded-For if present)
+     * Get the currently set customer ip or fetches the customers 'real' IP
+     * address (i.e. pulls out the address from X-Forwarded-For if present)
      *
      * @return String the customers IP address
      */
     private function get_customer_ip() {
-        $customer_ip = $_SERVER['REMOTE_ADDR'];
-        if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-            $forwarded_ips = explode(', ', $_SERVER['HTTP_X_FORWARDED_FOR']);
-            $customer_ip = $forwarded_ips[0];
+        if (!$this->customer_ip) {
+            $this->customer_ip = $_SERVER['REMOTE_ADDR'];
+            if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+                $forwarded_ips = explode(', ', $_SERVER['HTTP_X_FORWARDED_FOR']);
+                $this->customer_ip = $forwarded_ips[0];
+            }
         }
+        return $this->customer_ip;
+    }
 
-        return $customer_ip;
+    /**
+     * Allows explicitly setting the customer's IP address to be sent along with some requests.
+     *
+     * @return String the customers IP address
+     */
+    public function set_customer_ip($customer_ip) {
+        $this->customer_ip = $customer_ip;
     }
 
     /**

--- a/README.markdown
+++ b/README.markdown
@@ -76,6 +76,13 @@ Usage
 
 See the example folder for this example tied into a website.
 
+Example
+-------
+
+From within the `example` directory you can run `docker-compose up -d` and `docker-compose down` to start and stop (respectively) an apache web server running the php example.
+
+Once up, you can access the example website at http://localhost:8080/example/index.php URL to give it a go.
+
 Documentation
 -------------
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "fatzebra/fatzebra-php",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"repositories": [
 		{
 			"type": "vcs",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
 	"name": "fatzebra/fatzebra-php",
 	"version": "1.2.2",
+	"license": "GPL-2.0-or-later",
 	"repositories": [
 		{
 			"type": "vcs",

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2'
+
+services:
+
+    web:
+        image: 'php:7-apache'
+        ports:
+            - '8080:80'
+        volumes:
+            - '../:/var/www/html'

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '2'
+
+services:
+
+    tests:
+        image: 'phpunit/phpunit:latest'
+        entrypoint:
+            - /bin/sh
+            - -c
+        command:
+            - 'phpunit test/*.php'
+        volumes:
+            - '../:/app'

--- a/test/gateway_tests.php
+++ b/test/gateway_tests.php
@@ -240,6 +240,22 @@ class GatewayTest extends PHPUnit\Framework\TestCase {
 		$this->assertTrue($result->successful);
 		$this->assertNotNull($result->response->id);
 	}
+
+	/**
+	 * Testing a token authorization
+	 */
+	public function test_token_authorization() {
+	 $gw = new FatZebra\Gateway("TEST", "TEST", true, GW_URL);
+	 $gw->timeout = 30;
+
+	 $card = $gw->tokenize("Billy Blanks", "5123456789012346", "05/2023", "123");
+
+	 $result = $gw->token_authorization(100.00, "UNITTEST" . rand(), $card->response->token);
+
+	 $this->assertTrue($result->successful);
+	 $this->assertTrue($result->response->successful);
+	 $this->assertEquals($result->response->message, "Approved");
+	}
 }
 
 ?>


### PR DESCRIPTION
Hello,

In using this library we have found issues with the `FatZebra->token_authorization` method attempting to use several variables that do not exist.

This PR consists of 3 commits, the first adds some `docker-compose.yml` files for the `test` and `example` directories to more easily run tests locally with different PHP versions.

The next commit implements a test that if run will fail on:

```
PHPUnit 6.5.13 by Sebastian Bergmann, Julien Breux (Docker) and contributors.

...............IE                                                 17 / 17 (100%)

Time: 13.29 seconds, Memory: 4.00MB

There was 1 error:

1) GatewayTest::test_token_authorization
Undefined variable: token

/app/FatZebra.class.php:238
/app/test/gateway_tests.php:253

ERRORS!
Tests: 17, Assertions: 39, Errors: 1, Incomplete: 1.
```

The final commit passes the previously added test by fixing the `test_authorization` method.